### PR TITLE
Add Jest env to ESLint tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,4 +31,16 @@ export default [
       'eol-last': ['error', 'always'],
     },
   },
+  {
+    files: ['src/__tests__/**/*.{js,jsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: { ...globals.browser, ...globals.jest },
+      parserOptions: {
+        ecmaVersion: 'latest',
+        ecmaFeatures: { jsx: true },
+        sourceType: 'module',
+      },
+    },
+  },
 ]


### PR DESCRIPTION
## Summary
- configure ESLint for Jest test files
- allow Jest globals in `src/__tests__`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684201aa038c832892d16b60d138cc4f