### PR TITLE
Add testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,19 @@ The project uses Vite for building and the `gh-pages` package for deployment.
   npm run deploy
   ```
 
+## Testing
+
+Before running tests ensure all dependencies are installed. You can use either `npm ci` or `npm install`:
+
+```bash
+npm ci
+# or
+npm install
+```
+
+Execute the test suite with:
+
+```bash
+npm test
+```
+


### PR DESCRIPTION
## Summary
- add instructions for installing dependencies
- document command to run tests

## Testing
- `npm ci`
- `npm test` *(fails: Unable to fire a `click` event)*

------
https://chatgpt.com/codex/tasks/task_e_684201a9c4108328863775045a361bdd